### PR TITLE
Fix typo of the word "assign" in comments

### DIFF
--- a/1st Edition/C02/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C02/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/01 - Supersimple Rot/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/01 - Supersimple Rot/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/02 - Modularity/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/02 - Modularity/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/03 - iTunes Rotation/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/03 - iTunes Rotation/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/04 - Lock/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/04 - Lock/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/05 - Drawer/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/05 - Drawer/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C06/06 - Window Bounds (OS X)/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C06/06 - Window Bounds (OS X)/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/01 - Table Cells/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/01 - Table Cells/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/01b - Example for Table Header View/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/01b - Example for Table Header View/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/02 - Aspect/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/02 - Aspect/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/03 - Accordion/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/03 - Accordion/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/04 - Scroll/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/04 - Scroll/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/06 - Random Positions/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/06 - Random Positions/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/07 - Grids/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/07 - Grids/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/1st Edition/C07/08 - Damped Stretch/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/1st Edition/C07/08 - Damped Stretch/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C02/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C02/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView/NSView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 // If you use in production code, please make sure to add
 // namespace indicators to class category methods

--- a/2ndEdition/C06/01 - Supersimple Rot/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/01 - Supersimple Rot/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C06/02 - Modularity/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/02 - Modularity/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C06/03 - iTunes Rotation/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/03 - iTunes Rotation/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C06/04 - Lock/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/04 - Lock/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C06/05 - Drawer/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/05 - Drawer/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C06/06 - Window Bounds (OS X)/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C06/06 - Window Bounds (OS X)/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/01 - Table Cells/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/01 - Table Cells/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/01b - Example for Table Header View/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/01b - Example for Table Header View/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/02 - Custom Heights/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/02 - Custom Heights/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/03 - Aspect/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/03 - Aspect/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/04 - Accordion/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/04 - Accordion/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/05 - Hybrid Scrollview/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
+++ b/2ndEdition/C07/05 - Hybrid Scrollview/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView/NSView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 // If you use in production code, please make sure to add
 // namespace indicators to class category methods

--- a/2ndEdition/C07/06 - Paged Scroll View/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
+++ b/2ndEdition/C07/06 - Paged Scroll View/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView/NSView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 // If you use in production code, please make sure to add
 // namespace indicators to class category methods

--- a/2ndEdition/C07/08 - Random Positions/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/08 - Random Positions/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/C07/09 - Grids/Constraints/Constraint Matching/NSObject-Nametag.h
+++ b/2ndEdition/C07/09 - Grids/Constraints/Constraint Matching/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 #pragma mark - Support nametags universally
 @interface NSObject (Nametags)

--- a/2ndEdition/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
+++ b/2ndEdition/Constraints Pack/Nametag Utilities/NSObject/NSObject-Nametag.h
@@ -8,7 +8,7 @@
 
 // A nametag is an associated string object that can be assigned to any object.
 // Similar in intent and nature to UIView/NSView's "tag" property, it allows you to
-// assing readable text to objects for annotation and searching.
+// assign readable text to objects for annotation and searching.
 
 // If you use in production code, please make sure to add
 // namespace indicators to class category methods


### PR DESCRIPTION
Erica,

I have enjoyed reading the 2nd edition of your excellent book this holiday season.  I am now integrating your code into my project.  While touring the code I noticed a recurring typo in comment blocks of the word "assign" (appears as "assing").

My fork is nothing more then the correction to this typo in comments.

I humbly submit this fix to you.  Thanks!

John
jlindwall@yahoo.com
